### PR TITLE
Add 7-day filter for sleep data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # fitness
+
+`extract_sleep_data.py` parses the Apple Health `export.xml` file and
+writes sleep records to `sleep_data.csv`. Only records from the last
+seven days are included.

--- a/extract_sleep_data.py
+++ b/extract_sleep_data.py
@@ -11,13 +11,14 @@ Usage:
 
 import xml.etree.ElementTree as ET
 import csv
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 # ── CONFIG ───────────────────────────────────────────────────────────
 INPUT_FILE  = Path("export.xml")          # Edit if your xml is elsewhere
 OUTPUT_FILE = Path("sleep_data.csv")
 PREFIX      = "HKCategoryValueSleepAnalysis"
+LOOKBACK_DAYS = 7  # Number of days back from today to include
 # ──────────────────────────────────────────────────────────────────────
 
 
@@ -64,6 +65,10 @@ def main() -> None:
             except (KeyError, ValueError) as e:
                 skipped += 1
                 print(f"⚠️  Skipping record: {e}")
+                continue
+
+            cutoff = datetime.now(start.tzinfo) - timedelta(days=LOOKBACK_DAYS)
+            if start < cutoff:
                 continue
 
             duration_min = (end - start).total_seconds() / 60


### PR DESCRIPTION
## Summary
- filter `extract_sleep_data.py` results to only include the last 7 days
- document the new behaviour in the README

## Testing
- `python3 -m py_compile extract_sleep_data.py`


------
https://chatgpt.com/codex/tasks/task_e_6866463ce88c8320b0f7749a058fee56